### PR TITLE
attempt to address 'pointer' cursor issue raised by Montana on twitter

### DIFF
--- a/themes/thunderplains/source/javascripts/application.js
+++ b/themes/thunderplains/source/javascripts/application.js
@@ -1,5 +1,6 @@
 $(function() {
   initializeMap();
+  addCursorPointer();
 
   // Smooth Scroll
   $('a[href*=#]:not([href=#])').click(function() {
@@ -24,6 +25,10 @@ $(function() {
   });
 
 });
+
+function addCursorPointer() {
+  $('.schedule-talk').addClass('schedule-cursor-pointer');
+}
 
 // Map
 function initializeMap() {

--- a/themes/thunderplains/source/stylesheets/main.css
+++ b/themes/thunderplains/source/stylesheets/main.css
@@ -4543,7 +4543,7 @@ header {
       #schedule .schedule-list .schedule-keynote .schedule-talk .schedule-title h4 {
         font-size: 20px; }
   #schedule .schedule-list .schedule-talk {
-    cursor: pointer;
+    cursor: default;
     border-left: 5px solid #f2ece4;
     padding: 15px 20px 15px 10px; }
     #schedule .schedule-list .schedule-talk.schedule-room1 {
@@ -4554,6 +4554,8 @@ header {
       border-left-color: #e5c1a0; }
     #schedule .schedule-list .schedule-talk.no-modal {
       cursor: default; }
+    #schedule .schedule-list .schedule-talk.schedule-cursor-pointer {
+      cursor: pointer; }
     #schedule .schedule-list .schedule-talk img, #schedule .schedule-list .schedule-talk p {
       display: none; }
   @media only screen and (min-width: 992px) {

--- a/themes/thunderplains/source/stylesheets/main.sass
+++ b/themes/thunderplains/source/stylesheets/main.sass
@@ -291,7 +291,7 @@ header
           h4
             font-size: 20px
     .schedule-talk
-      cursor: pointer
+      cursor: default
       border-left: 5px solid $creme
       padding: 15px 20px 15px  10px
       &.schedule-room1
@@ -302,6 +302,8 @@ header
         border-left-color: $orange
       &.no-modal
         cursor: default
+      &.schedule-cursor-pointer
+        cursor: pointer
       img, p
         display: none
     @media only screen and (min-width: $break-medium)


### PR DESCRIPTION
This is an attempt to address the concern raised by @calcnerd256 on [twitter](https://twitter.com/calcnerd256/status/489842961287364608) regarding the 'pointer' cursor when js is disabled. 

This PR will make the cursor pointer only appear when js is enabled, but makes no attempt to display the content that would be revealed when clicked with js enabled. Perhaps this PR can generate some discussion about how best to reveal the talk descriptions when js is not enabled.
